### PR TITLE
Add pre- and post- install notes for GCP environments

### DIFF
--- a/docs/post-install/gcp.md
+++ b/docs/post-install/gcp.md
@@ -1,0 +1,125 @@
+# Paasify PKS on GCP
+
+## Post installation instructions
+
+At the completion of `terraform apply` you should see between 5 and 6 additional VM instances in your Google Cloud Console.
+
+At this point you have the base cloud infrastructure to support creating PKS clusters.
+
+To create and manage clusters we will need to complete some additional steps.
+
+### 1. Install prerequisite software
+
+You should download and install the following CLIs on your workstation or jumpbox
+
+* [PKS CLI](https://network.pivotal.io/products/pivotal-container-service/#/releases/551663/file_groups/2369)
+* [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+* [BOSH CLI](https://bosh.io/docs/cli-v2-install/)
+
+Consider using the install script below on a Linux jumpbox
+
+```
+#!/bin/sh
+
+# Install additional software on jumpbox
+
+sudo apt update --yes && \
+sudo apt install --yes jq && \
+sudo apt install --yes build-essential
+
+cd ~
+
+PIVNET_UAA_REFRESH_TOKEN=change_me
+
+PIVNET_VERSION=1.0.1
+wget -O pivnet https://github.com/pivotal-cf/pivnet-cli/releases/download/v${PIVNET_VERSION}/pivnet-linux-amd64-${PIVNET_VERSION} && \
+  chmod +x pivnet && \
+  sudo mv pivnet /usr/local/bin/
+
+BOSH_VERSION=6.2.1
+wget -O bosh https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-${BOSH_VERSION}-linux-amd64 && \
+  chmod +x bosh && \
+  sudo mv bosh /usr/local/bin/
+
+pivnet login --api-token="${PIVNET_UAA_REFRESH_TOKEN}" && \
+  pivnet download-product-files --product-slug='pivotal-container-service' --release-version='1.6.1' --product-file-id=579531 && \
+  mv pks-linux-amd64-1.6.1-build.20 pks && \
+  chmod +x pks && \
+  sudo mv pks /usr/local/bin
+
+curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl && \
+  chmod +x kubectl && \
+  sudo mv kubectl /usr/local/bin
+```
+> `tools.sh`
+
+### 2. Login to PKS
+
+If you haven't already, SSH into your jumpbox
+
+```
+cd paasify-pks/bin
+./pks-login.sh
+```
+
+### 3. Follow procedure for creating and configuring load balancer and cluster
+
+Each cluster will need a load balancer.
+
+Carefully follow steps `1-7` underneath the `Overview` section of [Creating and Configuring a GCP Load Balancer for Enterprise PKS Clusters](https://docs.pivotal.io/pks/1-6/gcp-cluster-load-balancer.html)
+
+
+#### Notes on naming
+
+Stick with the name you chose for the cluster.  Use it consistently as a prefix for each cloud resource you will create.
+
+Adopt a suffix convention for each cloud resource (e.g, load balancer `-lb`, IP address `-ip`).
+
+The network tag on a compute instance for a master node in a cluster is just the name suffixed with `-master`.
+
+The firewall rule should be prefixed with the sub-domain name, so name it something like
+
+```
+{sub-domain-name}.{cluster-name}-firewall
+```
+When configuring the firewall rule, be sure to obtain the public IP address for your jumpbox, and when prompted, choose a source filter (i.e., IP ranges), and enter a CIDR that includes IP address with `/32` (e.g., `38.227.140.195/32`).
+
+#### How could the post-install procedure be improved?
+
+Replace the manual steps above with automation; either we enhance the existing Terraform to complete these steps on our behalf, or we add a shell script.  Terraform is preferable as it may more appropriately disposition and manage the  life-cycle of the additional cloud resources that get created.
+
+#### Load balancer remarks
+
+
+* Consider setting up health checks
+* Be wary of fact that IP address for load-balancer may change
+  * if it does you'll need to update the `A` record DNS entry
+
+## Addendum
+
+### Sample commands
+
+```
+pks login -a https://api.pks.hagrid.ironleg.me -u paasify -p change_me --skip-ssl-validation
+```
+> PKS login
+
+```
+pks create-cluster dev-cluster-1 --external-hostname dev-cluster-1.hagrid.ironleg.me --plan small --num-nodes 3
+```
+> Create cluster
+
+```
+pks cluster dev-cluster-1
+```
+> Check-in on status of cluster creation
+
+```
+pks get-credentials dev-cluster-1
+```
+> Get credentials and set context
+
+```
+kubectl cluster-info
+```
+> Confirm you can access your cluster using the Kubernetes CLI

--- a/docs/pre-install/gcp.md
+++ b/docs/pre-install/gcp.md
@@ -41,7 +41,7 @@ SSH into the jumpbox
 #!/bin/sh
 
 # Connect to the jumbpbox
-GCP_PROJECT_ID=fe-cphillipson
+GCP_PROJECT_ID={project_id}
 
 gcloud compute ssh ubuntu@jbox-cc \
   --project "${GCP_PROJECT_ID}" \

--- a/docs/pre-install/gcp.md
+++ b/docs/pre-install/gcp.md
@@ -1,0 +1,95 @@
+# Paasify PKS on GCP
+
+## Pre installation instructions
+
+It's highly recommended to restrict access to your Kubernetes clusters.  Therefore, create a jumpbox in your Google cloud account, and install [Git](https://git-scm.com/downloads) and [Terraform](https://www.terraform.io/downloads.html).
+
+### Prerequisites
+
+* A Google Cloud [account](https://cloud.google.com/gcp/getting-started)
+
+You should have the [gcloud](https://cloud.google.com/sdk/install) SDK installed on your workstation.  Or just launch a [Google Cloud Shell](https://cloud.google.com/shell).
+
+### Scripts
+
+Consider using the install script below to create a Linux jumpbox
+
+```
+#!/bin/sh
+
+# Create your jumpbox from your local machine or Google Cloud Shell
+## Expects that an environment variable named GCP_PROJECT_ID has already been exported
+
+gcloud auth login --project ${GCP_PROJECT_ID} --quiet
+
+gcloud services enable compute.googleapis.com \
+  --project "${GCP_PROJECT_ID}"
+
+gcloud compute instances create "jbox-cc" \
+  --image-project "ubuntu-os-cloud" \
+  --image-family "ubuntu-1804-lts" \
+  --boot-disk-size "200" \
+  --machine-type=g1-small \
+  --project "${GCP_PROJECT_ID}" \
+  --zone "us-west1-a"
+```
+> `create-jumpbox.sh`
+
+SSH into the jumpbox
+
+```
+#!/bin/sh
+
+# Connect to the jumbpbox
+GCP_PROJECT_ID=fe-cphillipson
+
+gcloud compute ssh ubuntu@jbox-cc \
+  --project "${GCP_PROJECT_ID}" \
+  --zone "us-west1-a"
+```
+> `connect-to-jumpbox.sh`
+
+Authenticate (once) to Google Cloud
+
+```
+#!/bin/sh
+
+# Authenticate and authorize the jumpbox to work with project on Google Cloud Compute
+gcloud auth login --quiet
+```
+
+Install Git and Terraform
+
+```
+#!/bin/sh
+
+# Install necessary tools on jumpbox
+
+sudo apt update --yes && \
+sudo apt install --yes git
+
+cd ~
+
+TF_VERSION=0.12.23
+wget -O terraform.zip https://releases.hashicorp.com/terraform/${TF_VERSION}/terraform_${TF_VERSION}_linux_amd64.zip && \
+  unzip terraform.zip && \
+  sudo mv terraform /usr/local/bin && \
+  rm terraform.zip
+```
+
+Clone the repository
+
+```
+git clone https://github.com/niallthomson/paasify-pks
+```
+
+Add environment variables
+
+Set three environment variables.  You might want to put these into a `.env` file located in your `/home/ubuntu` directory and append `source ~/.env` to your `.bashrc` file.  `GOOGLE_CREDENTIALS` must be a single line devoid of newlines or carriage returns.  Escape occurrences of newline within the `private_key`.  A sample appears below, adapt for your needs.
+
+```
+GOOGLE_CREDENTIALS={ "type": "service_account", "project_id": "change_me", "private_key_id": "change_me", "private_key": "-----BEGIN PRIVATE KEY-----change_me-----END PRIVATE KEY-----\n", "client_email": "change_me@{project_id}.iam.gserviceaccount.com", "client_id": "change_me", "auth_uri": "https://accounts.google.com/o/oauth2/auth", "token_uri": "https://accounts.google.com/o/oauth2/token", "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs", "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/change_me" }
+GOOGLE_PROJECT={project_id}
+GOOGLE_REGION={region}
+```
+> `.env`


### PR DESCRIPTION
This PR is centered around pre and post installation steps for someone who may be uninitiated. It doesn't make too many assumptions about what may or may not already be installed, or what the user's background knowledge or experience may be.

Why am I asking you to add this?

I found `paasify-pks` to be very straight-forward to get started on my PKS evaluation journey, but it fell just a bit short.  What I desired after completing `terraform apply` was just enough supplemental documentation to get to the point where I could create a cluster, configure access, and begin using `kubectl` as quickly as possible.